### PR TITLE
fix: Modify to use sscanf

### DIFF
--- a/handson1/handson1.c
+++ b/handson1/handson1.c
@@ -72,7 +72,7 @@ unsigned long read_ulong(void){
     unsigned long val = 0ul;
     char tmp[0x10] = {'\0'};
     fgets(tmp, 0x10 - 1, stdin);
-    if(1 != sscanf_s(tmp, "%lx", &val)){
+    if(1 != sscanf(tmp, "%lx", &val)){
         exit(EXIT_FAILURE);
     }
     return val; 


### PR DESCRIPTION
# Fixed compile error

makeを実行したところ、sscanf_s関数が見つからなかったため、sscanf関数に変更しました。

```
root@8c7ec889b350:/ctf/work/handson1# make
/usr/bin/gcc -ggdb -O0 -fstack-protector-all -o handson1 -Wl,-z,relro,-z,now handson1.c
handson1.c: In function ‘read_ulong’:
handson1.c:75:13: warning: implicit declaration of function ‘sscanf_s’; did you mean ‘sscanf’? [-Wimplicit-function-declaration]
   75 |     if(1 != sscanf_s(tmp, "%lx", &val, sizeof(val))){
      |             ^~~~~~~~
      |             sscanf
/usr/bin/ld: /tmp/ccaF4k7y.o: in function `read_ulong':
/ctf/work/handson1/handson1.c:75: undefined reference to `sscanf_s'
collect2: error: ld returned 1 exit status
make: *** [Makefile:8: all] Error 1
```

お手数をおかけいたしますが、よろしくお願いいたします。